### PR TITLE
BUG: Update `polis.server` add missing packages

### DIFF
--- a/polis.server/requirements.txt
+++ b/polis.server/requirements.txt
@@ -9,6 +9,7 @@ httptools==0.6.4
 idna==3.10
 Mako==1.3.6
 MarkupSafe==3.0.2
+numpy==2.2.4
 psycopg2==2.9.10
 pydantic==2.9.2
 pydantic-settings==2.6.1

--- a/polis.server/requirements.txt
+++ b/polis.server/requirements.txt
@@ -20,6 +20,7 @@ PyYAML==6.0.2
 sniffio==1.3.1
 SQLAlchemy==2.0.36
 starlette==0.41.2
+scikit-learn==1.6.1
 typing_extensions==4.12.2
 uvicorn==0.32.0
 uvloop==0.21.0


### PR DESCRIPTION
Missing requirement of `numpy` and `sklearn` in `requirements.txt`